### PR TITLE
fixed bizzare gcc13 ada warnings and error

### DIFF
--- a/eepers.adb
+++ b/eepers.adb
@@ -158,6 +158,11 @@ procedure Eepers is
         X, Y: Integer;
     end record;
 
+	function "="(A, B: IVector2) return Boolean is
+	begin
+	    return A.X = B.X and then A.Y = B.Y;
+	end;
+
     type Cell is (Cell_None, Cell_Floor, Cell_Wall, Cell_Barricade, Cell_Door, Cell_Explosion);
     Cell_Size : constant Vector2 := (x => 50.0, y => 50.0);
 
@@ -188,11 +193,6 @@ procedure Eepers is
     function "<"(A, B: IVector2) return Boolean is
     begin
         return A.X < B.X and then A.Y < B.Y;
-    end;
-
-    function "="(A, B: IVector2) return Boolean is
-    begin
-        return A.X = B.X and then A.Y = B.Y;
     end;
 
     function "+"(A, B: IVector2) return IVector2 is


### PR DESCRIPTION
It worked on my machine. I have no idea why this would on any planet be an error, but looks like you need to define `=` before you use the type as that "freezes" it. maybe it has to do with the type needing an `=` operator to be used in comparisons somehow? only the oldest ada developers might know.

please check that this works with your gcc version too,