### PR TITLE
apply `* (1.0 / Command_Queue.Size)` to turn duration to make rapid movement feel less delayed

### DIFF
--- a/eepers.adb
+++ b/eepers.adb
@@ -936,7 +936,7 @@ procedure Eepers is
             when Command_Plant => null;
         end case;
     end record;
-    Command_Capacity: constant Natural := 5;
+    Command_Capacity: constant Natural := 3;
     type Command_Array is array (0..Command_Capacity-1) of Command;
     type Command_Queue_Record is record
         Items: Command_Array;
@@ -1494,10 +1494,14 @@ begin
                     Command_Enqueue(Command_Queue, (Kind => Command_Plant));
                 end if;
             end if;
-            if Command_Queue.Size /= 0 then
-                TURN_DURATION_SECS := BASE_TURN_DURATION_SECS * (1.0 / Float(Command_Queue.Size));
+            if Is_Key_Down(KEY_LEFT_SHIFT) then
+                TURN_DURATION_SECS := BASE_TURN_DURATION_SECS * 0.8;
             else
-                TURN_DURATION_SECS := BASE_TURN_DURATION_SECS;
+                if Command_Queue.Size /= 0 then
+                    TURN_DURATION_SECS := BASE_TURN_DURATION_SECS * (1.0 / Float(Command_Queue.Size));
+                else
+                    TURN_DURATION_SECS := BASE_TURN_DURATION_SECS;
+                end if;
             end if;
             
             Any_Key_Pressed := False;

--- a/eepers.adb
+++ b/eepers.adb
@@ -143,7 +143,8 @@ procedure Eepers is
             Put_Line("WARNING: could not load colors from file " & File_Name & ": " & Exception_Message(E));
     end;
 
-    TURN_DURATION_SECS      : constant Float := 0.125;
+    BASE_TURN_DURATION_SECS : constant Float := 0.125;
+    TURN_DURATION_SECS      :  Float := BASE_TURN_DURATION_SECS;
     GUARD_ATTACK_COOLDOWN   : constant Integer := 10;
     EEPER_EXPLOSION_DAMAGE  : constant Float := 0.45;
     GUARD_TURN_REGENERATION : constant Float := 0.01;
@@ -1493,6 +1494,12 @@ begin
                     Command_Enqueue(Command_Queue, (Kind => Command_Plant));
                 end if;
             end if;
+            if Command_Queue.Size /= 0 then
+                TURN_DURATION_SECS := BASE_TURN_DURATION_SECS * (1.0 / Float(Command_Queue.Size));
+            else
+                TURN_DURATION_SECS := BASE_TURN_DURATION_SECS;
+            end if;
+            
             Any_Key_Pressed := False;
             while not Any_Key_Pressed and then Get_Key_Pressed /= KEY_NULL loop
                 Any_Key_Pressed := True;


### PR DESCRIPTION
I kinda sneezed the code into the file crudely, might wanna rename some stuff or move some stuff around.