### PR TITLE
Android build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,10 @@ test.exe
 *.res
 eepers.app
 
+*.apk.idsig
+android/lib
+android/build
+eepers.apk
+
 .idea
 .DS_Store

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="io.github.tsoding.eepers"
+    android:versionCode="12"
+    android:versionName="1.2">
+
+  <application
+      android:allowBackup="false"
+      android:fullBackupContent="false"
+      android:icon="@drawable/ic_launcher"
+      android:label="@string/app_name"
+      android:hasCode="false">
+    <activity android:name="android.app.NativeActivity"
+              android:label="@string/app_name"
+              android:configChanges="orientation|keyboardHidden"
+        android:exported="true">
+      <meta-data android:name="android.app.lib_name"
+                 android:value="eepers" />
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+  </application>
+
+</manifest>

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -7,6 +7,7 @@
 
   <application
       android:allowBackup="false"
+      android:debuggable="true"
       android:fullBackupContent="false"
       android:icon="@drawable/ic_launcher"
       android:label="@string/app_name"

--- a/android/main.c
+++ b/android/main.c
@@ -48,8 +48,6 @@ int main(void) {
 
 	ALOGD("Initializing with eepersinit()");
 	eepersinit();
-
-
 	ALOGD("Entering Eepers main: _ada_eepers");
 	_ada_eepers();
 	ALOGD("Deinitializing with eepersfinal()");

--- a/android/main.c
+++ b/android/main.c
@@ -1,0 +1,58 @@
+#include <string.h>
+#include <stdlib.h>
+#include <android/log.h>
+#include <android/asset_manager.h>
+#include <android_native_app_glue.h>
+
+extern void eepersinit(void);
+extern void _ada_eepers(void);
+extern void eepersfinal(void);
+
+#define LOG_TAG "Eepers"
+#define ALOGD(...) __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
+
+// Dummy implementations to workaround GNAT-LLVM bugs
+typedef void __sigtramphandler_t (int signo, void *siginfo, void *sigcontext);
+
+void __gnat_sigtramp (int signo, void *siginfo, void *sigcontext, __sigtramphandler_t * handler) {
+	ALOGD("%s: Signal %d, siginfo %p, sigcontext %p, handler %p", __func__, signo, siginfo, sigcontext, handler);
+	exit(1);
+}
+unsigned char _r_debug[640*1024] = {};
+
+
+extern const char *GetApplicationDirectory(void);
+extern const char *GetWorkingDirectory(void);
+extern void SetLoadFileDataCallback(void *);
+
+extern struct android_app *GetAndroidApp(void);
+static struct android_app *app;
+
+const unsigned char *LoadFileDataCallback(const char *fileName, int *dataSize) {
+	if (memcmp(fileName, "assets/", strlen("assets/")) != 0) {
+		return 0;
+	}
+	fileName += strlen("assets/");
+
+	AAsset *asset = AAssetManager_open(app->activity->assetManager, fileName, AASSET_MODE_BUFFER);
+	*dataSize = AAsset_getLength(asset);
+	ALOGD("%s: Opening %s (size %d)", __func__, fileName, *dataSize);
+	unsigned char *data = malloc(*dataSize);
+	memcpy(data, AAsset_getBuffer(asset), *dataSize);
+	return data;
+}
+
+int main(void) {
+	app = GetAndroidApp();
+	SetLoadFileDataCallback(LoadFileDataCallback);
+
+	ALOGD("Initializing with eepersinit()");
+	eepersinit();
+
+
+	ALOGD("Entering Eepers main: _ada_eepers");
+	_ada_eepers();
+	ALOGD("Deinitializing with eepersfinal()");
+	eepersfinal();
+	ALOGD("%s: Done!", __func__);
+}

--- a/android/res/drawable-hdpi/ic_launcher.png
+++ b/android/res/drawable-hdpi/ic_launcher.png
@@ -1,0 +1,1 @@
+../../../assets/icon.png

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Eepers</string>
+</resources>

--- a/build-android.sh
+++ b/build-android.sh
@@ -70,12 +70,12 @@ done
 #  Build APK
 # ______________________________________________________________________________
 #
-$BUILD_TOOLS/aapt package -f -m \
+$BUILD_TOOLS/aapt package -f -m --min-sdk-version 29 --target-sdk-version $API \
 	-S android/res -J android/build -M android/AndroidManifest.xml \
 	-I $ANDROID_HOME/Sdk/platforms/android-$API/android.jar
 
 # Add resources and assets to APK
-$BUILD_TOOLS/aapt package -f \
+$BUILD_TOOLS/aapt package -f --min-sdk-version 29 --target-sdk-version $API \
 	-M android/AndroidManifest.xml -S android/res -A assets \
 	-I $ANDROID_HOME/Sdk/platforms/android-$API/android.jar -F eepers.apk
 

--- a/build-android.sh
+++ b/build-android.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+
+set -xe
+
+ABIS="arm64-v8a"
+API=33
+
+BUILD_TOOLS=$ANDROID_HOME/Sdk/build-tools/34.0.0
+TOOLCHAIN=$CLANG_R475365B_CUSTOM
+ANDROID_NDK=$ANDROID_HOME/Sdk/ndk/26.1.10909125
+NATIVE_APP_GLUE=$ANDROID_NDK/sources/android/native_app_glue
+LLVM_GNAT_BIN=$LLVM_GNAT/llvm-interface/bin
+
+SYSROOTS=$CLANG_R475365B_CUSTOM/../../../sysroots
+
+FLAGS="-ffunction-sections -funwind-tables -fstack-protector-strong -fPIC -Wall \
+	-Wformat -Werror=format-security -no-canonical-prefixes \
+	-DANDROID -DPLATFORM_ANDROID -D__ANDROID_API__=$API"
+
+mkdir -p android/res/drawable-hdpi
+mkdir -p android/lib/arm64-v8a
+mkdir -p android/build
+
+SRC="eepers.adb raylib.adb raymath.ads"
+OBJ="raylib raymath eepers"
+
+for ABI in $ABIS; do
+	case "$ABI" in
+		"armeabi-v7a")
+			CCTYPE="armv7a-linux-androideabi"
+			ARCH="arm"
+			ARCH_SYSROOT="arm"
+			LIBPATH="arm-linux-androideabi"
+			ABI_FLAGS="-std=c99 -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16"
+			;;
+
+		"arm64-v8a")
+			CCTYPE="aarch64-linux-android"
+			ARCH="aarch64"
+			ARCH_SYSROOT="arm64"
+			LIBPATH="aarch64-linux-android"
+			ABI_FLAGS="-std=c99 -target aarch64"
+			;;
+	esac
+	CC="$TOOLCHAIN/bin/clang"
+	SYSROOT=$SYSROOTS/ndk/$ARCH_SYSROOT
+	LLD=$CLANG_R475365B_CUSTOM/bin/ld.lld
+	INCLUDES="-I$NATIVE_APP_GLUE -I$SYSROOT/usr/include/$CCTYPE -I$SYSROOT/usr/include"
+
+	# Compile native app glue
+	#$CC $INCLUDES --target=$CCTYPE$API -c $NATIVE_APP_GLUE/android_native_app_glue.c -o android/build/native_app_glue.o $FLAGS $ABI_FLAGS
+    $CC $INCLUDES --target=$CCTYPE$API -c android/main.c -o android/build/main.o $FLAGS $ABI_FLAGS
+
+	# Compile project
+
+	for file in $SRC; do
+	   $LLVM_GNAT_BIN/llvm-gcc -g --target=aarch64-linux-android$API -fPIC -gnat2022 $file -c
+	done
+
+	$LLVM_GNAT/llvm-interface/bin/llvm-gnatbind -Leepers eepers.ali
+    $LLVM_GNAT/llvm-interface/bin/llvm-gnatlink eepers.ali -o android/lib/$ABI/libeepers.so --LINK="$LLD" android/build/*.o -shared \
+        --exclude-libs libatomic.a --build-id -z noexecstack -z relro -z now --warn-shared-textrel -u ANativeActivity_onCreate \
+        --sysroot=$SYSROOT -L$CLANG_R475365B_CUSTOM/lib/clang/16.0.2/lib/linux -L$CLANG_R475365B_CUSTOM/lib/clang/16.0.2/lib/linux/$ARCH \
+        -L$SYSROOT/usr/lib/$LIBPATH/$API -L$SYSROOT/usr/lib/$LIBPATH -Landroid/build -Lraylib/raylib-5.0_android_$ABI \
+        -lraylib -llog -landroid -lEGL -lGLESv2 -lOpenSLES -lc -lm -ldl -l:libclang_rt.builtins-$ARCH-android.a -lunwind
+done
+
+# ______________________________________________________________________________
+#
+#  Build APK
+# ______________________________________________________________________________
+#
+$BUILD_TOOLS/aapt package -f -m \
+	-S android/res -J android/build -M android/AndroidManifest.xml \
+	-I $ANDROID_HOME/Sdk/platforms/android-$API/android.jar
+
+# Add resources and assets to APK
+$BUILD_TOOLS/aapt package -f \
+	-M android/AndroidManifest.xml -S android/res -A assets \
+	-I $ANDROID_HOME/Sdk/platforms/android-$API/android.jar -F eepers.apk
+
+# Add libraries to APK
+cd android
+for ABI in $ABIS; do
+	$BUILD_TOOLS/aapt add ../eepers.apk lib/$ABI/libeepers.so
+done
+cd ..
+
+$BUILD_TOOLS/zipalign -f 4 eepers.apk eepers.4.apk
+$BUILD_TOOLS/apksigner sign --ks ~/.android/debug.keystore --ks-pass pass:android eepers.4.apk
+mv -f eepers.4.apk eepers.apk

--- a/eepers.ads
+++ b/eepers.ads
@@ -1,0 +1,2 @@
+procedure Eepers;
+pragma Export (C, Eepers, "_ada_eepers");


### PR DESCRIPTION
Running `./build-android.sh` requires some environment preparation.
The following variables need to be set:
```bash
export ANDROID_HOME=~/Android
export CLANG_R475365B_CUSTOM=/path/to/llvm-toolchain/out/install/linux-x86/clang-dev
export LLVM_GNAT=/path/to/llvm-toolchain/gnat-llvm
```