### PR TITLE
fix warning `renamed predefined unit is an obsolescent feature`

### DIFF
--- a/eepers.adb
+++ b/eepers.adb
@@ -1,5 +1,4 @@
-with Ada.Text_IO;
-with Text_IO; use Text_IO;
+with Ada.Text_IO; use Ada.Text_IO;
 with Interfaces.C; use Interfaces.C;
 with Raylib; use Raylib;
 with Raymath; use Raymath;


### PR DESCRIPTION
`eepers.adb:2:06: warning: renamed predefined unit is an obsolescent feature (RM J.1) [-gnatwj]`
absolutely no idea what this means, but doing this fixes it.