### PR TITLE
fix #9 by first calling `Game_Bombs_Turn`

### DIFF
--- a/eepers.adb
+++ b/eepers.adb
@@ -1401,8 +1401,8 @@ procedure Eepers is
                             Game_Explosions_Turn(Game);
                             Game_Items_Turn(Game);
                             Game_Player_Turn(Game, C.Dir);
-                            Game_Eepers_Turn(Game);
                             Game_Bombs_Turn(Game);
+                            Game_Eepers_Turn(Game);
                             Game.Duration_Of_Last_Turn := Get_Time - Start_Of_Turn;
                         end;
                     when Command_Plant =>
@@ -1420,8 +1420,8 @@ procedure Eepers is
                                 Game.Player.Prev_Eyes := Game.Player.Eyes;
                                 Game.Player.Prev_Position := Game.Player.Position;
 
-                                Game_Eepers_Turn(Game);
                                 Game_Bombs_Turn(Game);
+                                Game_Eepers_Turn(Game);
 
                                 if Game.Player.Bombs > 0 then
                                     for Bomb of Game.Bombs loop


### PR DESCRIPTION
This pr closes #9 by calling `Game_Bombs_Turn` before `Game_Eepers_Turn`

https://github.com/tsoding/eepers/assets/97286671/89d5e239-989f-4621-a528-8a18bcfcca1e

