### PR TITLE
Fix zoom issue on smaller screens

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,8 @@
 
 - @rexim - Added items that extend the amount of bombs you can carry
 - @rexim - Do not restart on Any Key Press. Restart automatically after 2 seconds. 
-- @ProgKea - Fix the Boss killing the Player on the same turn as it does - https://github.com/tsoding/eepers/pull/24
+- @ProgKea - Fix the Boss killing the Player on the same turn as it dies - https://github.com/tsoding/eepers/pull/24
+- @slukovic - Camera adjusts its zoom on bigger screen - https://github.com/tsoding/eepers/pull/27
 - ...
 
 # Eepers v1.3

--- a/eepers.adb
+++ b/eepers.adb
@@ -1017,6 +1017,10 @@ procedure Eepers is
     begin
         Game.Camera.offset := Camera_Offset;
         Game.Camera.target := Game.Camera.target + Camera_Velocity*Get_Frame_Time;
+        --  TODO: animate zoom similarly to Game.Camera.target
+        --    So it looks cool when you resize the game in the window mode.
+        --  TODO: The tutorial signs look gross on bigger screens.
+        --    We need to do something with the fonts
         Game.Camera.zoom := C_Float'Max(Screen_Size.x/1920.0, Screen_Size.y/1080.0);
     end;
 


### PR DESCRIPTION
I have an issue on a smaller screen where the game feels too zoomed in. Even the first boss is more difficult because it's often outside the screen and the turn counter isn't visible. This fixes it by zooming out the camera a bit.

I assumed from the streams that the game is designed on a 1080p screen and the cell and map sizes are chosen to look good on that screen. So I used it as the reference zoom level.

I had to refactor the code that updates camera. Currently the camera target is set to (0, 0) and the offset is updated accordingly, but zooming doesn't work correctly in that case. 

This has been mentioned in #3. While agree that it's not a big deal it does spoil level design a bit (e.g. on a 4K screen the entire "UrMom" chamber can be seen from the first bomb generator).

I'm not sure this is the best way to solve this issue, but the zoom level can now easily be changed based on different parameters. For example we might wan't to zoom out on small screens but leave it as it is on larger screens.

Screenshots from a 1366x768 screen.

- before
![eepers_before](https://github.com/tsoding/eepers/assets/6297137/eaeb5f29-c070-45ea-886d-26225c7e9f0a)

- after
![eepers_after](https://github.com/tsoding/eepers/assets/6297137/8011898d-d1ae-47ff-97ee-39cad5d54b29)
